### PR TITLE
Add --builds [n|all] and --summarize as options

### DIFF
--- a/bin/summarize_failures.dart
+++ b/bin/summarize_failures.dart
@@ -1,25 +1,48 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
+import 'package:args/args.dart';
 import 'package:http/http.dart' as http;
 
 const _prefix = 'http://build.chromium.org/p/client.dart';
 const _defaultSuffix = 'steps/steps/logs/stdio/text';
 const _annotatedStepsSuffix = 'steps/annotated_steps/logs/stdio/text';
 
+ArgParser parser = new ArgParser(allowTrailingOptions: true)
+  ..addFlag('show-repro',
+      negatable: false,
+      defaultsTo: false,
+      help: 'Whether to show reproduction command.')
+  ..addOption('builds',
+      defaultsTo: '1',
+      help: 'Number of builds to get.\n'
+          'Only works when only specifying bot name.\n'
+          'Will fetch latest n builds. Also accepts "all".')
+  ..addFlag('summarize',
+      negatable: false,
+      defaultsTo: false,
+      help: 'Use together with --builds [n|all].\n'
+          'Will summarize findings.\n'
+          'E.g. if one test failed on two builds it will show that.');
+
 main(args) async {
-  if (args.length == 0) {
+  ArgResults options = parser.parse(args);
+  if (options.rest.length != 1) {
     print('''
 Prints a list of tests whose expectations was incorrect in a single bot run.
 This includes tests that failed, or test that were expected to fail but started
 passing.
 
-usage: bot_failure_summary <descriptor> [--show-repro]
+usage: bot_failure_summary <descriptor> [--show-repro] [--all] [--summarize]
 
 where <descriptor> can be:
   - a full url to the stdout of a specific bot.
   - the segment of the url containing the bot name and build id number.
   - the name of the bot, in which case the tool finds the latest build and show
     results for it.
+
+Other parameters:
+${parser.usage}
 
 Examples:
   bot_failure_summary https://build.chromium.org/p/client.dart/builders/dart2js-win8-ie11-be/builds/232/steps/steps/logs/stdio
@@ -28,32 +51,74 @@ Examples:
 ''');
     exit(1);
   }
-  var arg = args[0];
-  var url;
+
+  var arg = options.rest[0];
+  var urls = [];
   if (arg.startsWith('http:') || arg.startsWith('https://')) {
-    url = arg;
+    urls.add(arg);
   } else if (arg.contains('/')) {
     // arg is of the form: dart2js-linux-chromeff-4-4-be/builds/183
     if (!arg.endsWith('/')) arg = '$arg/';
-    url = '$_prefix/builders/$arg';
+    String url = '$_prefix/builders/$arg';
     if (arg.contains('dartium')) {
       url = '$url$_annotatedStepsSuffix';
     } else {
       url = '$url$_defaultSuffix';
     }
+    urls.add(url);
   } else {
     var builder = arg;
     var response = await http.get('$_prefix/json/builders/$builder/?as_text=1');
     var json = JSON.decode(response.body);
     var isBuilding = json['state'] == 'building';
-    var lastBuild = json['cachedBuilds'].last - (isBuilding ? 1 : 0);
-    url = '$_prefix/builders/$builder/builds/$lastBuild/';
-    if (builder.contains('dartium')) {
-      url = '$url$_annotatedStepsSuffix';
-    } else {
-      url = '$url$_defaultSuffix';
+    var buildNums = [];
+    int numBuildsLeft =
+        int.parse(options['builds'], onError: (s) => s == "all" ? 100000 : 0);
+    buildNums.addAll(json['cachedBuilds']);
+    if (isBuilding) buildNums.removeLast();
+    for (var buildNum in buildNums.reversed) {
+      if (--numBuildsLeft < 0) break;
+      String url = '$_prefix/builders/$builder/builds/$buildNum/';
+      if (builder.contains('dartium')) {
+        url = '$url$_annotatedStepsSuffix';
+      } else {
+        url = '$url$_defaultSuffix';
+      }
+      urls.add(url);
     }
   }
+
+  if (urls.length != 1) {
+    print('Will download ${urls.length} urls.');
+    print('');
+  }
+
+  Map<String, int> combinedResult = {};
+  for (String url in urls) {
+    Set<String> result = await processUrl(
+      url,
+      options['show-repro'],
+    );
+    for (String key in result) {
+      combinedResult[key] = (combinedResult[key] ?? 0) + 1;
+    }
+  }
+
+  if (options['summarize']) {
+    print("Summary:");
+    if (combinedResult.isEmpty) {
+      print("No changes seen.");
+    }
+    combinedResult.keys
+        .map((key) =>
+            "${_pad(combinedResult[key], 2, left: true, padchar: '0')}: $key")
+        .toList()
+          ..sort()
+          ..reversed.forEach(print);
+  }
+}
+
+Future<Set<String>> processUrl(url, bool showRepro) async {
   if (url.endsWith('/stdio')) url = '$url/text';
   print('Loading data from: $url');
   var response = await http.get(url);
@@ -62,8 +127,6 @@ Examples:
     print('HttpError: ${response.reasonPhrase}');
     exit(1);
   }
-
-  bool showRepro = args.length > 1 && args[1] == '--show-repro';
 
   var body = response.body;
 
@@ -116,24 +179,28 @@ Examples:
   var last;
   var total = 0;
   var passing = 0;
+  Set<String> changes = new Set<String>();
   for (var record in records) {
     if (last == record) continue;
     var status = _pad('${record.expected} => ${_actualString(record)}', 36);
     print('$status ${record.config} ${record.suite} ${record.test}');
+    changes.add('$status ${record.config} ${record.suite} ${record.test}');
     if (showRepro) print('  repro: ${record.repro}');
     last = record;
     total++;
     if (record.isPassing) passing++;
   }
-  print(
-      'Total: ${total} unexpected result(s), $passing now passing, ${total - passing} now failing.');
+  print('Total: ${total} unexpected result(s), $passing now passing, ${total -
+          passing} now failing.');
   print('');
+
+  return changes;
 }
 
-_pad(s, n, {left: false}) {
+_pad(s, n, {left: false, padchar: ' '}) {
   s = '$s';
   if (s.length > n) return s;
-  var padding = ' ' * (n - s.length);
+  var padding = padchar * (n - s.length);
   return left ? '$padding$s' : '$s$padding';
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: bot_failures
 dependencies:
   http: ^0.11.3+3
+  args:
 executables:
   bot_failure_summary: summarize_failures


### PR DESCRIPTION
I've added two options:
--builds [n|all] so you can get more than one build when specifying a bot; and
--summarize so, when you get more than one build, you can get a summary. This makes it easier to see if a test has flakes several times.

I've forked, pushed, and now opening a pull request. I don't actually know if that's the way to do it. If not, I apologize.